### PR TITLE
Potential fix for code scanning alert no. 53: Client-side cross-site scripting

### DIFF
--- a/packages/sbg-server/package.json
+++ b/packages/sbg-server/package.json
@@ -90,7 +90,8 @@
     "toastr": "^2.1.4",
     "upath": "^2.0.1",
     "write-file-atomic": "^5.0.1",
-    "yaml": "^2.3.4"
+    "yaml": "^2.3.4",
+    "dompurify": "^3.2.6"
   },
   "devDependencies": {
     "@babel/core": "^7.23.9",

--- a/packages/sbg-server/src/post/index.ts
+++ b/packages/sbg-server/src/post/index.ts
@@ -134,6 +134,8 @@ export default function routePost(this: SBGServer, api: apis.Application) {
           stack: findPost.stack
         });
       }
+      const DOMPurify = require('dompurify');
+      findPost.rawbody = DOMPurify.sanitize(findPost.rawbody);
       res.render('post/edit2.html', { post: findPost });
     })
   );

--- a/packages/sbg-server/src/views/post/edit2.html
+++ b/packages/sbg-server/src/views/post/edit2.html
@@ -60,7 +60,7 @@
   <main>
     <div id="editor"></div>
     <div class="markdown-body" id="preview"></div>
-    <div id="default-value">{{ post.rawbody|safe }}</div>
+    <div id="default-value">{{ post.rawbody }}</div>
     <script id="post-data" type="application/json">{{ post | json(2) }}</script>
   </main>
 


### PR DESCRIPTION
Potential fix for [https://github.com/dimaslanjaka/static-blog-generator/security/code-scanning/53](https://github.com/dimaslanjaka/static-blog-generator/security/code-scanning/53)

To fix the issue, the `post.rawbody` value must be sanitized or escaped before being rendered in the HTML template. This can be achieved by removing the `safe` filter and ensuring that the value is properly escaped by the template engine. Alternatively, if the application requires raw HTML to be displayed, the input should be sanitized using a library like `DOMPurify` to remove any malicious scripts or tags.

**Steps to fix:**
1. Remove the `safe` filter from `post.rawbody` in the HTML template.
2. If raw HTML rendering is required, sanitize `post.rawbody` using a library like `DOMPurify` in the `index.ts` file before passing it to the template.
3. Ensure that all user input is validated and sanitized before being used in the application.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
